### PR TITLE
swap return value of isPausing()

### DIFF
--- a/src/ofxSimpleTimer.h
+++ b/src/ofxSimpleTimer.h
@@ -18,7 +18,7 @@ class ofxSimpleTimer {
     static ofEvent<string> TIMER_COUNT;
     static ofEvent<string> TIMER_COMPLETE;
 
-    inline bool isPausing() { return flag_update_enabled; };
+    inline bool isPausing() { return !flag_update_enabled; };
     inline int getCurrentCount() { return counter; };
     inline int getRepeatCount() { return repeat_count; };
     inline int getDuration() { return duration; };


### PR DESCRIPTION
Hey,
I've stumbled accross this tiny inconsistency in `isPausing` as i expected it to be the opposite of  `update_enable` (aka enabled or paused)